### PR TITLE
Fix VS 2019 support

### DIFF
--- a/TrimLineEnds/source.extension.vsixmanifest
+++ b/TrimLineEnds/source.extension.vsixmanifest
@@ -9,11 +9,11 @@
     <Tags>Whitespace, Cleanup</Tags>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[11.0,16.0]" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Premium" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Ultimate" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Fixes the version constraints for Visual Studio 2019 (see issue #8).

Built, installed and tested on VS 2019 Professional.